### PR TITLE
Fix: Unused Variables for Beam Calculation Causing Build Errors

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -24,7 +24,6 @@ const App: React.FC = () => {
     prompt,
     roundRecap,
     summary,
-    scores,
     roundSubmissions,
     error,
     localPlayer,
@@ -569,7 +568,6 @@ const App: React.FC = () => {
           countdownValue={countdownValue}
           prompt={prompt}
           roundRecap={roundRecap}
-          scores={scores}
           currentGuess={currentGuess}
           hasSubmitted={hasSubmitted}
           opponentSubmitted={opponentSubmitted ?? false}

--- a/client/src/components/GameSummaryCard.tsx
+++ b/client/src/components/GameSummaryCard.tsx
@@ -20,10 +20,6 @@ export function GameSummaryCard({ summary, players, localPlayerId, onClose }: Ga
   };
   const reasonLabel = reasonLabelMap[summary.reason] ?? summary.reason;
 
-  const bannerGradient = didWin
-    ? 'from-emerald-400/80 via-emerald-500/70 to-cyan-400/60'
-    : 'from-rose-600/80 via-rose-700/60 to-fuchsia-600/50';
-
   return (
     <div className="fixed inset-0 z-40 flex items-center justify-center bg-slate-950/80 backdrop-blur-sm px-4">
       <div className="relative w-full max-w-4xl overflow-hidden rounded-[32px] border border-white/10 bg-slate-950/70 p-6 shadow-[0_25px_65px_rgba(4,0,24,0.85)]">

--- a/client/src/components/WizardBeam.tsx
+++ b/client/src/components/WizardBeam.tsx
@@ -55,7 +55,6 @@ const WIZARDS: Wizard[] = [
 
 interface WizardBeamProps {
   players: Player[];
-  scores: Record<string, number>;
   beamOffset?: number;
   roundRecap?: RoundRecapPayload | null;
   localPlayerId?: string | null;
@@ -63,7 +62,7 @@ interface WizardBeamProps {
 
 const BEAM_RANGE = 100;
 
-export function WizardBeam({ players, scores, beamOffset = 0, roundRecap, localPlayerId }: WizardBeamProps) {
+export function WizardBeam({ players, beamOffset = 0, roundRecap, localPlayerId }: WizardBeamProps) {
   // Ensure we have both players, with host on left
   const hostPlayer = players.find(p => p.isHost);
   const nonHostPlayer = players.find(p => !p.isHost);

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import Logo from '../components/Logo';
 import { RoundRecapCard } from '../components/RoundRecapCard';
 import { CountdownDisplay } from '../components/CountdownDisplay';
@@ -13,7 +12,6 @@ interface GamePageProps {
   countdownValue: number | null;
   prompt: SpellPromptPayload | null;
   roundRecap: RoundRecapPayload | null;
-  scores: Record<string, number>;
   currentGuess: string;
   hasSubmitted: boolean;
   opponentSubmitted: boolean;
@@ -33,7 +31,6 @@ const GamePage: React.FC<GamePageProps> = ({
   countdownValue,
   prompt,
   roundRecap,
-  scores,
   currentGuess,
   hasSubmitted,
   opponentSubmitted,
@@ -200,7 +197,6 @@ const GamePage: React.FC<GamePageProps> = ({
           <div className="mt-auto pt-2">
             <WizardBeam
               players={duel.players}
-              scores={scores}
               beamOffset={duel.beamOffset}
               roundRecap={roundRecap}
               localPlayerId={localPlayer?.id ?? null}

--- a/client/src/pages/LandingPage.tsx
+++ b/client/src/pages/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import Logo from '../components/Logo';
 import WizardAvatarSelectorModal from '../components/WizardAvatarSelectorModal';
 import HowToPlayModal from '../components/HowToPlayModal';


### PR DESCRIPTION
Self-explanatory.
Beam pos determined by ``beamOffset``, not ``scores``.