### PR TITLE
Fix lobby room code normalization

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -322,7 +322,7 @@ Requires `ELEVENLABS_API_KEY`. Skips existing files. **Append-only** catalog rul
 | Rate limiting                   | None                                           |
 | Payload schema validation       | TS types only; runtime destructuring can throw |
 | `wizardId` validation           | Pass-through string                            |
-| Room-code normalize consistency | Some handlers use raw `roomCode`               |
+| Room-code normalize consistency | Fixed: all lobby handlers normalize before lookup |
 | Speed bonus qualification       | Fixed: guesses below 30% accuracy receive zero speed bonus |
 | Public MP3 scraping             | Determined users can map audio over time       |
 | Custom mode leak                | `spellText` intentionally sent for TTS         |

--- a/docs/PRODUCTION_READINESS.md
+++ b/docs/PRODUCTION_READINESS.md
@@ -25,7 +25,7 @@ CI runs client/server tests and builds on pushes and pull requests. Not re-run a
 | B1 | **Post-duel EntryPage flash** | **Not confirmed visible.** Server emits `duel:completed` + `lobby:state` back-to-back; React batches → Lobby under summary in normal play. EntryPage removed from App (2026-07); remaining risk was theoretical only. |
 | B2 | **Host create forces game screen before lobby exists** | **Fixed (2026-07).** Host stays on Landing with Host Settings modal **Creating…** until `lobby:state`; EntryPage deleted. |
 | B3 | **No reconnect / seat reclaim** | Disconnect → `leaveCurrentLobby` (forfeit if in duel). New `socket.id` cannot reclaim player slot. Client clears `socketId` on disconnect → `localPlayer` null. |
-| B4 | **Room code normalize inconsistency** | `lobby:join` / `duel:submitSpell` normalize codes; `lobby:setReady`, `lobby:updateSettings`, `lobby:startDuel` look up raw `roomCode`. Lowercase codes can fail those ops. |
+| B4 | **Fixed (2026-08): Room code normalize inconsistency** | All lobby handlers normalize room codes before lookup. A socket-handler regression test covers lowercase/padded codes through settings, ready, and duel start. |
 | B5 | **Fixed (2026-07): Speed bonus qualification** | Existing time curve is awarded only at `accuracy >= 0.30`; lower-accuracy guesses receive zero bonus. Exact boundary, empty/wrong, timeout, and beam integration are tested. |
 | B6 | **CSV upload errors always show “Not a .csv!”** | `GameSettingsControls` ignores actual `uploadError` string for display. |
 | B7 | **Fixed (2026-08): Invalid Tailwind class `scale-85`** | Removed the ineffective transform; keyboard sizing is now responsive through its actual key styles. |

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -28,7 +28,7 @@ Status values: `Not Started` | `In Progress` | `Blocked` | `Complete`
 
 | Field              | Value                                                                                                                                                                                      |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Status**         | Not Started                                                                                                                                                                                |
+| **Status**         | Complete                                                                                                                                                                                   |
 | **Why**            | Ready/start/settings can fail if clients send non-normalized codes; join works, later ops do not.                                                                                          |
 | **Affected files** | `server/src/sockets/index.ts`                                                                                                                                                              |
 | **Acceptance**     | `setReady`, `updateSettings`, `startDuel`, and any new lobby ops use the same `normalizeRoomCode` path as join/submit; tests or manual checklist cover lowercase join codes through start. |
@@ -124,7 +124,7 @@ Status values: `Not Started` | `In Progress` | `Blocked` | `Complete`
 | Field              | Value                                                                                                                             |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
 | **Status**         | In Progress                                                                                                                       |
-| **Why**            | Scoring and duel-flow tests are now present; sanitize, queue, and room-code coverage are still incomplete.                        |
+| **Why**            | Scoring, duel-flow, and room-code handler tests are now present; sanitize and queue coverage are still incomplete.                |
 | **Affected files** | new test setup under `server/` (and optionally client), `scoring.ts`, sanitize helpers, `spells.ts`                               |
 | **Acceptance**     | CI runs tests; coverage includes Levenshtein/scoring, custom-word sanitize, spell queue length, and room-code normalize behavior. |
 

--- a/server/src/sockets/index.ts
+++ b/server/src/sockets/index.ts
@@ -139,7 +139,8 @@ export function registerSocketHandlers(
       });
 
       socket.on('lobby:setReady', ({ roomCode, ready }) => {
-        const lobby = lobbies.get(roomCode);
+        const code = normalizeRoomCode(roomCode);
+        const lobby = lobbies.get(code);
         if (!lobby) {
           return sendError(socket, 'lobby no longer exists');
         }
@@ -157,7 +158,8 @@ export function registerSocketHandlers(
       });
 
       socket.on('lobby:updateSettings', ({ roomCode, settings }) => {
-        const lobby = lobbies.get(roomCode);
+        const code = normalizeRoomCode(roomCode);
+        const lobby = lobbies.get(code);
         if (!lobby) {
           return sendError(socket, 'lobby no longer exists');
         }
@@ -177,7 +179,8 @@ export function registerSocketHandlers(
       });
 
       socket.on('lobby:startDuel', ({ roomCode }) => {
-        const lobby = lobbies.get(roomCode);
+        const code = normalizeRoomCode(roomCode);
+        const lobby = lobbies.get(code);
         if (!lobby) {
           return sendError(socket, 'lobby no longer exists');
         }
@@ -201,7 +204,7 @@ export function registerSocketHandlers(
           ready: false,
         }));
 
-        console.log(`lobby ${roomCode} started a duel`);
+        console.log(`lobby ${code} started a duel`);
         broadcastLobbyState(io, lobby);
         duelManager.startDuel(lobby);
       });

--- a/server/test/socketHandlers.test.ts
+++ b/server/test/socketHandlers.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Server as SocketIOServer, Socket } from 'socket.io';
+import type {
+  ClientToServerEvents,
+  InterServerEvents,
+  ServerToClientEvents,
+  SocketData,
+} from '../../shared/types/socket';
+import { registerSocketHandlers } from '../src/sockets';
+
+type TestIo = SocketIOServer<
+  ClientToServerEvents,
+  ServerToClientEvents,
+  InterServerEvents,
+  SocketData
+>;
+type TestSocket = Socket<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>;
+
+interface RecordedEvent {
+  event: keyof ServerToClientEvents;
+  payload: unknown;
+}
+
+function createSocketHarness() {
+  let connectionHandler: ((socket: TestSocket) => void) | null = null;
+  const sockets: FakeSocket[] = [];
+
+  class FakeSocket {
+    readonly data: SocketData = {};
+    readonly events: RecordedEvent[] = [];
+    readonly rooms = new Set<string>();
+    private readonly handlers = new Map<string, (payload?: unknown) => void>();
+
+    constructor(readonly id: string) {}
+
+    on(event: string, handler: (payload?: unknown) => void) {
+      this.handlers.set(event, handler);
+      return this;
+    }
+
+    emit(event: keyof ServerToClientEvents, payload: unknown) {
+      this.events.push({ event, payload });
+      return true;
+    }
+
+    join(roomCode: string) {
+      this.rooms.add(roomCode);
+      return Promise.resolve();
+    }
+
+    leave(roomCode: string) {
+      this.rooms.delete(roomCode);
+      return Promise.resolve();
+    }
+
+    clientEmit(event: keyof ClientToServerEvents, payload?: unknown) {
+      const handler = this.handlers.get(event);
+      if (!handler) {
+        throw new Error(`No server handler registered for ${event}`);
+      }
+      handler(payload);
+    }
+
+    payloads<T>(event: keyof ServerToClientEvents) {
+      return this.events.filter((entry) => entry.event === event).map((entry) => entry.payload as T);
+    }
+  }
+
+  const io = {
+    on: vi.fn((event: string, handler: (socket: TestSocket) => void) => {
+      if (event === 'connection') {
+        connectionHandler = handler;
+      }
+    }),
+    to: vi.fn((roomCode: string) => ({
+      emit: (event: keyof ServerToClientEvents, payload: unknown) => {
+        sockets
+          .filter((socket) => socket.rooms.has(roomCode))
+          .forEach((socket) => socket.emit(event, payload));
+      },
+    })),
+  } as unknown as TestIo;
+
+  registerSocketHandlers(io);
+
+  const connect = (id: string) => {
+    const socket = new FakeSocket(id);
+    sockets.push(socket);
+    if (!connectionHandler) {
+      throw new Error('Socket.IO connection handler was not registered');
+    }
+    connectionHandler(socket as unknown as TestSocket);
+    return socket;
+  };
+
+  return { connect };
+}
+
+describe('lobby room-code normalization', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('normalizes codes for settings, ready, and starting a duel', () => {
+    const { connect } = createSocketHarness();
+    const host = connect('host');
+    const guest = connect('guest');
+
+    host.clientEmit('lobby:create', {
+      playerName: 'Merlin',
+      requestId: 'create-1',
+    });
+    const createdLobby = host.payloads<{ roomCode: string }>('lobby:state').at(-1)!;
+    const variantCode = `  ${createdLobby.roomCode.toLowerCase()}  `;
+
+    guest.clientEmit('lobby:join', {
+      roomCode: variantCode,
+      playerName: 'Morgana',
+    });
+    host.clientEmit('lobby:updateSettings', {
+      roomCode: variantCode,
+      settings: { rounds: 10 },
+    });
+    host.clientEmit('lobby:setReady', { roomCode: variantCode, ready: true });
+    guest.clientEmit('lobby:setReady', { roomCode: variantCode, ready: true });
+    host.clientEmit('lobby:startDuel', { roomCode: variantCode });
+
+    expect(host.payloads('error')).toHaveLength(0);
+    expect(guest.payloads('error')).toHaveLength(0);
+    expect(host.payloads<{ settings: { rounds: number } }>('lobby:state').at(-2)?.settings.rounds).toBe(10);
+    expect(host.payloads<{ phase: string }>('lobby:state').at(-1)?.phase).toBe('in-duel');
+    expect(host.payloads('duel:started')).toHaveLength(1);
+    expect(guest.payloads('duel:started')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
- Normalize room codes before ready, settings, and duel-start lobby lookups.
- Add a Socket.IO handler regression test covering lowercase and whitespace-padded codes through duel start.
- Update the release plan, production-readiness audit, and architecture notes to mark C2 complete.
- Validate with 23 client tests, 38 server tests, and successful client and server production builds.